### PR TITLE
feat: validate lesson file based on media type

### DIFF
--- a/src/main/java/com/riwi/classes_media_management/dtos/LessonDTO.java
+++ b/src/main/java/com/riwi/classes_media_management/dtos/LessonDTO.java
@@ -1,14 +1,19 @@
 package com.riwi.classes_media_management.dtos;
 
 import com.riwi.classes_media_management.enums.MediaTypes;
+
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class LessonDTO {
 
     @NotBlank(message = "Name cannot be blank")
@@ -17,7 +22,8 @@ public class LessonDTO {
     @NotNull(message = "Media Type cannot be null")
     private MediaTypes mediaType;
 
-    private String content;
+    @Builder.Default
+    private String content = "";
 
     private MultipartFile file;
 

--- a/src/main/java/com/riwi/classes_media_management/enums/AudioFormats.java
+++ b/src/main/java/com/riwi/classes_media_management/enums/AudioFormats.java
@@ -1,0 +1,16 @@
+package com.riwi.classes_media_management.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum AudioFormats {
+  WEBM("audio/webm"),
+  MP3("audio/mpeg");
+
+  private final String format;
+
+  AudioFormats(String format) {
+    this.format = format;
+  }
+
+}

--- a/src/main/java/com/riwi/classes_media_management/enums/VideoFormats.java
+++ b/src/main/java/com/riwi/classes_media_management/enums/VideoFormats.java
@@ -1,0 +1,15 @@
+package com.riwi.classes_media_management.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum VideoFormats {
+  MP4("video/mp4"),
+  WEBM("video/webm");
+
+  private final String format;
+
+  VideoFormats(String format) {
+    this.format = format;
+  }
+}

--- a/src/main/java/com/riwi/classes_media_management/services/LessonsService.java
+++ b/src/main/java/com/riwi/classes_media_management/services/LessonsService.java
@@ -5,13 +5,17 @@ import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.riwi.classes_media_management.dtos.LessonDTO;
 import com.riwi.classes_media_management.entities.Lesson;
 import com.riwi.classes_media_management.enums.MediaTypes;
 import com.riwi.classes_media_management.services.interfaces.ILessonsService;
+import com.riwi.classes_media_management.storage.FileFormatValidator;
 import com.riwi.classes_media_management.storage.IStorageService;
+import com.riwi.classes_media_management.storage.exceptions.StorageException;
 
 @Service
 public class LessonsService implements ILessonsService {
@@ -20,10 +24,29 @@ public class LessonsService implements ILessonsService {
   @Autowired
   private IStorageService storageService;
 
+  @Autowired
+  private FileFormatValidator fileFormatValidator;
+
   @Override
   public Lesson create(LessonDTO lessonDTO) {
+    // Validate mediaType as document
+    var isMediaTypeDocument = lessonDTO.getMediaType().equals(MediaTypes.DOCUMENT);
+    var hasContentProperty = !lessonDTO.getContent().isEmpty();
+    var isFileEmpty = lessonDTO.getFile().isEmpty();
+
+    if (!isFileEmpty && isMediaTypeDocument && hasContentProperty)
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Uploading file when 'mediaType' is 'DOCUMENT'");
+
+    // Validate mediaType as Video or Audio
+    var isVideoOrAudioFormatValid = fileFormatValidator.validate(lessonDTO.getFile(), lessonDTO.getMediaType());
+    boolean isFileValid = (isMediaTypeDocument && hasContentProperty)
+        || isVideoOrAudioFormatValid;
+
+    if (!isFileValid)
+      throw new StorageException("Invalid file format for the selected media type");
+
     String fileUrl = null;
-    boolean uplodingAudioOrVideo = !lessonDTO.getMediaType().equals(MediaTypes.DOCUMENT);
+    boolean uplodingAudioOrVideo = !isMediaTypeDocument;
     // Store file in case of audios or videos
     if (uplodingAudioOrVideo) {
       try {

--- a/src/main/java/com/riwi/classes_media_management/storage/FileFormatValidator.java
+++ b/src/main/java/com/riwi/classes_media_management/storage/FileFormatValidator.java
@@ -1,0 +1,25 @@
+package com.riwi.classes_media_management.storage;
+
+import java.util.Arrays;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.riwi.classes_media_management.enums.AudioFormats;
+import com.riwi.classes_media_management.enums.MediaTypes;
+import com.riwi.classes_media_management.enums.VideoFormats;
+
+@Component
+public class FileFormatValidator {
+  public boolean validate(MultipartFile file, MediaTypes mediaType) {
+    return switch (mediaType) {
+      case VIDEO -> Arrays.stream(VideoFormats.values())
+          .map(VideoFormats::getFormat)
+          .anyMatch(videoFormat -> videoFormat.equals(file.getContentType()));
+      case AUDIO -> Arrays.stream(AudioFormats.values())
+          .map(AudioFormats::getFormat)
+          .anyMatch(audioFormat -> audioFormat.equals(file.getContentType()));
+      default -> false;
+    };
+  }
+}


### PR DESCRIPTION
# Validations
- Lessons created with `mediaType` set to `"DOCUMENT"` cannot receive a file upload. The content property should be used instead.
- Audios and Videos are validated based on `AudioFormats` and `VideoFormats` enums respectively.

# TO-DO

- [ ] Add exception handlers for exceptions thrown in `LessonsService`.